### PR TITLE
Frontrunning protection

### DIFF
--- a/src/sDola.sol
+++ b/src/sDola.sol
@@ -21,7 +21,7 @@ contract sDola is ERC4626 {
     uint public prevK;
     uint public targetK;
     uint public lastKUpdate;
-    mapping (uint => uint) public dailyRevenue;
+    mapping (uint => uint) public weeklyRevenue;
 
     constructor(
         address _dola,
@@ -52,10 +52,10 @@ contract sDola is ERC4626 {
     }
 
     function totalAssets() public view override returns (uint) {
-        uint day = block.timestamp / 1 days;
-        uint timeElapsed = block.timestamp - (day * 1 days);
-        uint remainingLastRevenue = dailyRevenue[day - 1] * (1 days - timeElapsed) / 1 days;
-        return savings.balanceOf(address(this)) - remainingLastRevenue - dailyRevenue[day];
+        uint week = block.timestamp / 7 days;
+        uint timeElapsed = block.timestamp - (week * 7 days);
+        uint remainingLastRevenue = weeklyRevenue[week - 1] * (7 days - timeElapsed) / 7 days;
+        return savings.balanceOf(address(this)) - remainingLastRevenue - weeklyRevenue[week];
     }
 
     function getK() public view returns (uint) {
@@ -92,7 +92,7 @@ contract sDola is ERC4626 {
         require(dolaReserve * dbrReserve >= getK(), "Invariant");
         asset.transferFrom(msg.sender, address(this), exactDolaIn);
         savings.stake(exactDolaIn, address(this));
-        dailyRevenue[block.timestamp / 1 days] += exactDolaIn;
+        weeklyRevenue[block.timestamp / 7 days] += exactDolaIn;
         dbr.transfer(to, exactDbrOut);
         emit Buy(msg.sender, to, exactDolaIn, exactDbrOut);
     }

--- a/test/sDola.t.sol
+++ b/test/sDola.t.sol
@@ -73,7 +73,7 @@ contract sDolaTest is Test {
     }
 
     function test_buyDBR(uint exactDolaIn, uint exactDbrOut) public {
-        vm.warp(1 days); // for totalAssets()
+        vm.warp(7 days); // for totalAssets()
         dbr.mint(address(sdola), 1e18);
         assertEq(sdola.getDbrReserve(), 1e18, "dbr reserve");
         exactDbrOut = bound(exactDbrOut, 1, sdola.getDbrReserve());
@@ -94,19 +94,19 @@ contract sDolaTest is Test {
             assertEq(dbr.balanceOf(address(1)), exactDbrOut, "dbr balance");
             assertEq(sdola.getDbrReserve(), newDbrReserve, "dbr reserve");
             assertEq(sdola.getDolaReserve(), sdola.getK() / newDbrReserve, "dola reserve");
-            assertEq(sdola.dailyRevenue(block.timestamp / 1 days), exactDolaIn, "daily revenue");
+            assertEq(sdola.weeklyRevenue(block.timestamp / 7 days), exactDolaIn, "weekly revenue");
             assertEq(sdola.totalAssets(), 0, "total assets");
-            vm.warp(2 days);
+            vm.warp(14 days);
             assertEq(sdola.totalAssets(), 0, "total assets");
-            vm.warp(2.25 days);
+            vm.warp(14 days + (7 days / 4));
             assertApproxEqAbs(sdola.totalAssets(), exactDolaIn / 4, 1, "total assets");
-            vm.warp(2.5 days);
+            vm.warp(14 days + (7 days / 2));
             assertApproxEqAbs(sdola.totalAssets(), exactDolaIn / 2, 1, "total assets");
-            vm.warp(3 days);
+            vm.warp(21 days);
             assertEq(sdola.totalAssets(), exactDolaIn, "total assets");
-            vm.warp(3 days + 1);
+            vm.warp(21 days + 1);
             assertEq(sdola.totalAssets(), exactDolaIn, "total assets");
-            vm.warp(4 days);
+            vm.warp(28 days);
             assertEq(sdola.totalAssets(), exactDolaIn, "total assets");
         }
     }
@@ -150,7 +150,7 @@ contract sDolaTest is Test {
     }
 
     function test_totalAssets(uint amount) public {
-        vm.warp(1 days); // for totalAssets()
+        vm.warp(7 days); // for totalAssets()
         amount = bound(amount, 1, type(uint).max);
         assertEq(sdola.totalAssets(), 0);
         dola.mint(address(this), amount);
@@ -160,7 +160,7 @@ contract sDolaTest is Test {
     }
 
     function test_deposit(uint amount) public {
-        vm.warp(1 days); // for totalAssets()
+        vm.warp(7 days); // for totalAssets()
         amount = bound(amount, 1, type(uint).max);
         uint shares = sdola.convertToShares(amount);
         dola.mint(address(this), amount);
@@ -173,7 +173,7 @@ contract sDolaTest is Test {
     }
 
     function test_mint(uint shares) public {
-        vm.warp(1 days); // for totalAssets()
+        vm.warp(7 days); // for totalAssets()
         shares = bound(shares, 1, type(uint).max);
         uint amount = sdola.convertToAssets(shares);
         dola.mint(address(this), amount);
@@ -199,7 +199,7 @@ contract sDolaTest is Test {
     }
 
     function test_withdraw(uint amount) public {
-        vm.warp(1 days); // for totalAssets()
+        vm.warp(7 days); // for totalAssets()
         uint MIN_BALANCE = 1e16; // 1 cent
         amount = bound(amount, MIN_BALANCE + 1, sqrt(type(uint).max));
         uint shares = sdola.convertToShares(amount);
@@ -222,7 +222,7 @@ contract sDolaTest is Test {
     }
 
     function test_redeem(uint shares) public {
-        vm.warp(1 days); // for totalAssets()
+        vm.warp(7 days); // for totalAssets()
         uint MIN_BALANCE = 1e16; // 1 cent
         shares = bound(shares, MIN_BALANCE + 1, sdola.convertToShares(sqrt(type(uint).max)));
         uint amount = sdola.convertToAssets(shares);

--- a/test/sDola.t.sol
+++ b/test/sDola.t.sol
@@ -73,6 +73,7 @@ contract sDolaTest is Test {
     }
 
     function test_buyDBR(uint exactDolaIn, uint exactDbrOut) public {
+        vm.warp(1 days); // for totalAssets()
         dbr.mint(address(sdola), 1e18);
         assertEq(sdola.getDbrReserve(), 1e18, "dbr reserve");
         exactDbrOut = bound(exactDbrOut, 1, sdola.getDbrReserve());
@@ -93,6 +94,20 @@ contract sDolaTest is Test {
             assertEq(dbr.balanceOf(address(1)), exactDbrOut, "dbr balance");
             assertEq(sdola.getDbrReserve(), newDbrReserve, "dbr reserve");
             assertEq(sdola.getDolaReserve(), sdola.getK() / newDbrReserve, "dola reserve");
+            assertEq(sdola.dailyRevenue(block.timestamp / 1 days), exactDolaIn, "daily revenue");
+            assertEq(sdola.totalAssets(), 0, "total assets");
+            vm.warp(2 days);
+            assertEq(sdola.totalAssets(), 0, "total assets");
+            vm.warp(2.25 days);
+            assertApproxEqAbs(sdola.totalAssets(), exactDolaIn / 4, 1, "total assets");
+            vm.warp(2.5 days);
+            assertApproxEqAbs(sdola.totalAssets(), exactDolaIn / 2, 1, "total assets");
+            vm.warp(3 days);
+            assertEq(sdola.totalAssets(), exactDolaIn, "total assets");
+            vm.warp(3 days + 1);
+            assertEq(sdola.totalAssets(), exactDolaIn, "total assets");
+            vm.warp(4 days);
+            assertEq(sdola.totalAssets(), exactDolaIn, "total assets");
         }
     }
 
@@ -135,6 +150,7 @@ contract sDolaTest is Test {
     }
 
     function test_totalAssets(uint amount) public {
+        vm.warp(1 days); // for totalAssets()
         amount = bound(amount, 1, type(uint).max);
         assertEq(sdola.totalAssets(), 0);
         dola.mint(address(this), amount);
@@ -144,6 +160,7 @@ contract sDolaTest is Test {
     }
 
     function test_deposit(uint amount) public {
+        vm.warp(1 days); // for totalAssets()
         amount = bound(amount, 1, type(uint).max);
         uint shares = sdola.convertToShares(amount);
         dola.mint(address(this), amount);
@@ -156,6 +173,7 @@ contract sDolaTest is Test {
     }
 
     function test_mint(uint shares) public {
+        vm.warp(1 days); // for totalAssets()
         shares = bound(shares, 1, type(uint).max);
         uint amount = sdola.convertToAssets(shares);
         dola.mint(address(this), amount);
@@ -181,6 +199,7 @@ contract sDolaTest is Test {
     }
 
     function test_withdraw(uint amount) public {
+        vm.warp(1 days); // for totalAssets()
         uint MIN_BALANCE = 1e16; // 1 cent
         amount = bound(amount, MIN_BALANCE + 1, sqrt(type(uint).max));
         uint shares = sdola.convertToShares(amount);
@@ -203,6 +222,7 @@ contract sDolaTest is Test {
     }
 
     function test_redeem(uint shares) public {
+        vm.warp(1 days); // for totalAssets()
         uint MIN_BALANCE = 1e16; // 1 cent
         shares = bound(shares, MIN_BALANCE + 1, sdola.convertToShares(sqrt(type(uint).max)));
         uint amount = sdola.convertToAssets(shares);


### PR DESCRIPTION
This PR guards against an attack vector where a DBR buyer sandwiches their own swap with a deposit before and a withdraw after in order to capture most of the DOLA proceeds of the sale.

The solution is to not accrue DOLA proceeds immediately on the same day but we stream all DOLA proceeds of any given day over the 24 hours of the next day starting 00:00 UTC.