### PR TITLE
Inflation attack safeguards

### DIFF
--- a/src/DolaSavings.sol
+++ b/src/DolaSavings.sol
@@ -73,7 +73,6 @@ contract DolaSavings {
 
     /**
      * @dev Constructor for DolaSavings.
-     * @dev Important to do an initial mint of deadshares to prevent inflation attacks causing lossy rounding precision 
      * @param _dbr Address of the DBR token contract.
      * @param _dola Address of the DOLA token contract.
      * @param _gov Address of governance.

--- a/src/sDola.sol
+++ b/src/sDola.sol
@@ -18,6 +18,10 @@ interface IERC20 {
     function balanceOf(address) external view returns (uint);
 }
 
+/**
+ * @title sDola
+ * @dev Auto-compounding ERC4626 wrapper for DolaSacings utilizing xy=k auctions.
+ */
 contract sDola is ERC4626 {
     
     uint constant MIN_BALANCE = 10**16; // 1 cent
@@ -30,6 +34,14 @@ contract sDola is ERC4626 {
     uint public lastKUpdate;
     mapping (uint => uint) public weeklyRevenue;
 
+    /**
+     * @dev Constructor for sDola contract.
+     * Important to make initial share mint high enough to avoid potential rounding issues.
+     * @param _dola Address of the DOLA token.
+     * @param _savings Address of the DolaSavings contract.
+     * @param _gov Address of the governance.
+     * @param _K Initial value for the K variable used in calculations.
+     */
     constructor(
         address _dola,
         address _savings,
@@ -49,15 +61,28 @@ contract sDola is ERC4626 {
         _;
     }
 
+    /**
+     * @dev Hook that is called after tokens are deposited into the contract.
+     * @param assets The amount of assets that were deposited.
+     */    
     function afterDeposit(uint256 assets, uint256) internal override {
         savings.stake(assets, address(this));
     }
 
+    /**
+     * @dev Hook that is called before tokens are withdrawn from the contract.
+     * @param assets The amount of assets to withdraw.
+     */
     function beforeWithdraw(uint256 assets, uint256) internal override {
         require(totalAssets() >= assets + MIN_BALANCE, "Insufficient assets");
         savings.unstake(assets);
     }
 
+    /**
+     * @dev Calculates the total assets controlled by the contract.
+     * Weekly revenue is distributed linearly over the following week.
+     * @return The total assets in the contract.
+     */
     function totalAssets() public view override returns (uint) {
         uint week = block.timestamp / 7 days;
         uint timeElapsed = block.timestamp % 7 days;
@@ -65,6 +90,10 @@ contract sDola is ERC4626 {
         return savings.balanceOf(address(this)) - remainingLastRevenue - weeklyRevenue[week];
     }
 
+    /**
+     * @dev Returns the current value of K, which is a weighted average between prevK and targetK.
+     * @return The current value of K.
+     */
     function getK() public view returns (uint) {
         uint duration = 7 days;
         uint timeElapsed = block.timestamp - lastKUpdate;
@@ -76,18 +105,35 @@ contract sDola is ERC4626 {
         return (prevK * prevWeight + targetK * targetWeight) / duration;
     }
 
+    /**
+     * @dev Calculates the DOLA reserve based on the current DBR reserve.
+     * @return The calculated DOLA reserve.
+     */
     function getDolaReserve() public view returns (uint) {
         return getK() / getDbrReserve();
     }
 
+    /**
+     * @dev Calculates the DOLA reserve for a given DBR reserve.
+     * @param dbrReserve The DBR reserve value.
+     * @return The calculated DOLA reserve.
+     */
     function getDolaReserve(uint dbrReserve) public view returns (uint) {
         return getK() / dbrReserve;
     }
 
+    /**
+     * @dev Returns the current DBR reserve as the sum of dbr balance and claimable dbr
+     * @return The current DBR reserve.
+     */
     function getDbrReserve() public view returns (uint) {
         return dbr.balanceOf(address(this)) + savings.claimable(address(this));
     }
 
+    /**
+     * @dev Sets a new target K value.
+     * @param _K The new target K value.
+     */
     function setTargetK(uint _K) external onlyGov {
         require(_K > getDbrReserve(), "K must be larger than dbr reserve");
         prevK = getK();
@@ -96,6 +142,14 @@ contract sDola is ERC4626 {
         emit SetTargetK(_K);
     }
 
+    /**
+     * @dev Allows users to buy DBR with DOLA.
+     * Never expose this directly to a UI as it's likely to cause a loss unless a transaction is executed immediately.
+     * Instead use the sDolaHelper function or custom smart contract code.
+     * @param exactDolaIn The exact amount of DOLA to spend.
+     * @param exactDbrOut The exact amount of DBR to receive.
+     * @param to The address that will receive the DBR.
+     */
     function buyDBR(uint exactDolaIn, uint exactDbrOut, address to) external {
         require(to != address(0), "Zero address");
         savings.claim(address(this));
@@ -111,20 +165,37 @@ contract sDola is ERC4626 {
         emit Buy(msg.sender, to, exactDolaIn, exactDbrOut);
     }
 
+    /**
+     * @dev Sets a new pending governance address.
+     * @param _gov The address of the new pending governance.
+     */
     function setPendingGov(address _gov) external onlyGov {
         pendingGov = _gov;
     }
 
+    /**
+     * @dev Allows the pending governance to accept its role.
+     */
     function acceptGov() external {
         require(msg.sender == pendingGov, "ONLY PENDINGGOV");
         gov = pendingGov;
         pendingGov = address(0);
     }
 
+    /**
+     * @dev Re-approves the DOLA token to be spent by the DolaSavings contract.
+     */
     function reapprove() external {
         asset.approve(address(savings), type(uint).max);
     }
 
+    /**
+     * @dev Allows governance to sweep any ERC20 token from the contract.
+     * @dev Excludes the ability to sweep DBR tokens.
+     * @param token The address of the ERC20 token to sweep.
+     * @param amount The amount of tokens to sweep.
+     * @param to The recipient address of the swept tokens.
+     */
     function sweep(address token, uint amount, address to) public onlyGov {
         require(address(dbr) != token, "Not authorized");
         IERC20(token).transfer(to, amount);

--- a/src/sDola.sol
+++ b/src/sDola.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT License
 pragma solidity 0.8.21;
 
 import "lib/solmate/src/mixins/ERC4626.sol";
@@ -21,6 +21,8 @@ interface IERC20 {
 /**
  * @title sDola
  * @dev Auto-compounding ERC4626 wrapper for DolaSacings utilizing xy=k auctions.
+ * WARNING: While this vault is safe to be used as collateral in lending markets, it should not be allowed as a borrowable asset.
+ * Any protocol in which sudden, large and atomic increases in the value of an asset may be a securit risk should not integrate this vault.
  */
 contract sDola is ERC4626 {
     
@@ -36,7 +38,7 @@ contract sDola is ERC4626 {
 
     /**
      * @dev Constructor for sDola contract.
-     * Important to make initial share mint high enough to avoid potential rounding issues.
+     * WARNING: Important to make initial share mint high enough to avoid potential rounding issues.
      * @param _dola Address of the DOLA token.
      * @param _savings Address of the DolaSavings contract.
      * @param _gov Address of the governance.
@@ -144,7 +146,7 @@ contract sDola is ERC4626 {
 
     /**
      * @dev Allows users to buy DBR with DOLA.
-     * Never expose this directly to a UI as it's likely to cause a loss unless a transaction is executed immediately.
+     * WARNING: Never expose this directly to a UI as it's likely to cause a loss unless a transaction is executed immediately.
      * Instead use the sDolaHelper function or custom smart contract code.
      * @param exactDolaIn The exact amount of DOLA to spend.
      * @param exactDbrOut The exact amount of DBR to receive.

--- a/src/sDola.sol
+++ b/src/sDola.sol
@@ -40,7 +40,7 @@ contract sDola is ERC4626 {
 
     /**
      * @dev Constructor for sDola contract.
-     * WARNING: Important to make initial share mint high enough to avoid potential rounding issues.
+     * WARNING: MIN_SHARES will always be unwithdrawable from the vault. Deployer should deposit enough to mint MIN_SHARES to avoid causing user grief.
      * @param _dola Address of the DOLA token.
      * @param _savings Address of the DolaSavings contract.
      * @param _gov Address of the governance.


### PR DESCRIPTION
Add a MIN_SHARES constant that must exist after depositing and after withdrawing.

Add a MAX_ASSET constant that puts a ceiling on the amount of assets that can exist in the vault.