### PR TITLE
Fix sDola.t.sol test

### DIFF
--- a/test/sDola.t.sol
+++ b/test/sDola.t.sol
@@ -30,7 +30,7 @@ contract sDolaTest is Test {
     }
 
     function test_constructor() public {
-        assertEq(sdola.name(), "Super Dola");
+        assertEq(sdola.name(), "Staked Dola");
         assertEq(sdola.symbol(), "sDOLA");
         assertEq(sdola.decimals(), 18);
         assertEq(sdola.gov(), gov);


### PR DESCRIPTION
Currently the `test_constructor` test in `sDola.t.sol` fails as `sdola.name()` is supposed to be `"Staked Dola"` and not `"Super Dola"` as it is in the test.